### PR TITLE
Add Test Model and Create-Test-Table Migration

### DIFF
--- a/backend/src/prisma/migrations/20250718125832_create_test_table/migration.sql
+++ b/backend/src/prisma/migrations/20250718125832_create_test_table/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE `Test` (
+    `id` VARCHAR(191) NOT NULL,
+    `subject` VARCHAR(191) NOT NULL,
+    `description` VARCHAR(191) NOT NULL,
+    `questionCount` INTEGER NOT NULL,
+    `difficulty` ENUM('EASY', 'NORMAL', 'HARD') NOT NULL DEFAULT 'EASY',
+    `tags` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -23,3 +23,20 @@ model User {
 
   @@map("users")
 }
+
+model Test {
+  id            String     @id @default(uuid())
+  subject       String
+  description   String
+  questionCount Int
+  difficulty    Difficulty @default(EASY)
+  tags          String
+
+  @@map("tests")
+}
+
+enum Difficulty {
+  EASY
+  NORMAL
+  HARD
+}


### PR DESCRIPTION
### ✅ Summary

This pull request introduces a new `Test` model to the backend's Prisma schema, along with a migration to create the corresponding database table. This model is intended to store metadata about tests or quizzes, including difficulty, tags, and the number of questions. This lays the groundwork for future features involving test creation, organization, and retrieval.

---

### 🔧 Changes Introduced

#### 1. **Prisma Schema Update** (`backend/src/prisma/schema.prisma`)  
Added the following:

##### `Test` model:
```prisma
model Test {
  id            String     @id @default(uuid())
  subject       String
  description   String
  questionCount Int
  difficulty    Difficulty @default(EASY)
  tags          String

  @@map("tests")
}
